### PR TITLE
permit signals renaming

### DIFF
--- a/cocomod/wishbone/driver.py
+++ b/cocomod/wishbone/driver.py
@@ -76,7 +76,9 @@ class Wishbone(BusDriver):
     _optional_signals = ["sel", "err", "stall", "rty"]
 
 
-    def __init__(self, entity, name, clock, width=32, **kwargs):
+    def __init__(self, entity, name, clock, width=32, signals_dict=None, **kwargs):
+        if signals_dict is not None:
+            self._signals=signals_dict
         BusDriver.__init__(self, entity, name, clock, **kwargs)
         # Drive some sensible defaults (setimmediatevalue to avoid x asserts)
         self._width = width


### PR DESCRIPTION
Maybe I do not understand something, but the only solution I found to set different name on my signals is changing this.

(according to[ this issue](https://github.com/wallento/cocomod-wishbone/issues/2))

With this pull request, I can rename signal like it : 
```python
        self.wbs = WishboneMaster(self._dut, "io_wbs",
                                  self.clock, width=16,
                                  signals_dict={"cyc":  "cyc_i",
                                                "stb":  "stb_i",
                                                "we":   "we_i",
                                                "adr":  "adr_i",
                                                "datwr":"dat_i",
                                                "datrd":"dat_o",
                                                "ack":  "ack_o" })
```