### PR TITLE
migrate syntax for last cocotb compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     description="Cocotb Wishbone modules",
     long_description=long_description,
     packages=["cocotbext.wishbone"],
-    install_requires=['cocotb'],
+    install_requires=['cocotb>=1.6.0', 'cocotb_bus'],
     setup_requires=[
         'setuptools_scm',
     ],


### PR DESCRIPTION
Changes:
* requirements: `cocotb>=1.6.0` and `cocotb_bus`.
* `cocotb.drivers` now is `cocotb_bus.drivers`.
* `cocotb.monitors` now is `cocotb_bus.monitors`.
* decorator `@cocotb.coroutine` is not longer needed. Replaced with `async/await` syntax.
* `signal <= value` is deprecated. The new syntax is `signal.value = value`.
* bufgix in `rty` signal read, in `cocotbext/wishbone/monitor.py`