### PR TITLE
Fix missing word

### DIFF
--- a/cocotbext/wishbone/driver.py
+++ b/cocotbext/wishbone/driver.py
@@ -1,7 +1,6 @@
 
-
 import cocotb
-from cocotb.triggers import RisingEdge, Event
+from cocotb.triggers import FallingEdge, RisingEdge, Event
 from cocotb_bus.drivers import BusDriver
 from cocotb.result import TestFailure
 from cocotb.binary import BinaryValue
@@ -247,7 +246,7 @@ class WishboneMaster(Wishbone):
         Reader for slave replies
         """
         count = 0
-        clkedge = RisingEdge(self.clock)
+        clkedge = FallingEdge(self.clock)
         while self.busy:
             ack, reply = self._get_reply()
             # valid reply?

--- a/cocotbext/wishbone/driver.py
+++ b/cocotbext/wishbone/driver.py
@@ -256,7 +256,7 @@ class WishboneMaster(Wishbone):
                 #append reply and meta info to result buffer
                 tmpRes =  WBRes(ack=reply, sel=None, adr=None, datrd=datrd, datwr=None, waitIdle=None, waitStall=None, waitAck=self._clk_cycle_count, cti=None, bte=None)
                 self._res_buf.append(tmpRes)
-                self._acked_ops += 1
+
             await clkedge
             count += 1
 


### PR DESCRIPTION
This PR fix the missing byte on read operations as stated in https://github.com/wallento/cocotbext-wishbone/issues/28 and fix the double increment of the ack counter. Indeed, this variable was incremented in the `WishboneMaster._read()` method AND the `WishboneMaster._wait_ack()` method.